### PR TITLE
Feature/support pass error back

### DIFF
--- a/lib/passport-keystone/strategy.js
+++ b/lib/passport-keystone/strategy.js
@@ -132,7 +132,18 @@ Strategy.prototype.authenticate = function(req, options) {
       } else {
         if (!client._identity.token.id) {
           if (self._passErrorBack) {
-            return self.error('Auth token not generated');
+            return self.error({
+              failCode: 'Unauthorized',
+              statusCode: 401,
+              message: 'Error (401): Unauthorized',
+              result: {
+                error: {
+                  message: 'Auth token not generated',
+                  code: 401,
+                  title: 'Auth token not generated'
+                }
+              }
+            });
           } else {
             return self.fail('Auth token not generated');
           }

--- a/lib/passport-keystone/strategy.js
+++ b/lib/passport-keystone/strategy.js
@@ -56,6 +56,7 @@ function Strategy(options, verify) {
   this._region = options.region || '';
   this._authUrl = options.authUrl || '';
   this._tenantId = options.tenantId || '';
+  this._passErrorBack = options.passErrorBack || false;
 
   passport.Strategy.call(this);
   this.name = 'keystone';
@@ -123,9 +124,19 @@ Strategy.prototype.authenticate = function(req, options) {
   client.auth(function(err) {
     try {
       if (err) {
+        if (self._passErrorBack) {
+          return self.error(err);
+        } else {
           return self.fail(err);
+        }
       } else {
-        if (!client._identity.token.id) return self.fail('Auth token not generated');
+        if (!client._identity.token.id) {
+          if (self._passErrorBack) {
+            return self.error('Auth token not generated');
+          } else {
+            return self.fail('Auth token not generated');
+          }
+        }
         if (self._verify) {
           if (self._passReqToCallback) {
             return self._verify(req, client._identity, verified(self));

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   "dependencies": {
     "passport-strategy": "~1.0.0",
     "pkginfo": "~0.3.0",
-    "pkgcloud": "~0.9.0"
+    "pkgcloud": "Hopebaytech/pkgcloud#master"
   }
 }


### PR DESCRIPTION
Add an option `passErrorBack`.
By default it's `false`, which return a 401 when login fails.
When set to `true`, it will return error object to caller's error handling routes.
